### PR TITLE
store mock cache outside of container to speed up repeated build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ RUN usermod -a -G mock builder
 
 VOLUME ["/rpmbuild"]
 
+# create mock cache on external volume to speed up build
+RUN install -g mock -m 2775 -d /rpmbuild/cache/mock
+RUN echo "config_opts['cache_topdir'] = '/rpmbuild/cache/mock'" >> /etc/mock/site-defaults.cfg
+
 ADD ./build-rpm.sh /build-rpm.sh
 RUN chmod +x /build-rpm.sh
 #RUN setcap cap_sys_admin+ep /usr/sbin/mock

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ chown -R 1000:1000 /tmp/rpmbuild
 ```
 In this folder you can put the src.rpms to rebuild.
 
+This folder will also store mock cache directories that allow to speed up repeated build
+
 ## Execute the container to build RPMs
 
 To execute the docker container and rebuild RPMs four SRPMs you can run it in this way:


### PR DESCRIPTION
Hello Marco

I found your project by accident ;-)  , searching around docker and mock

Here is a patch that speed up building by storing mock caches outside container.
This also lower containers disk consumption

Regards, and see you soon

Laurent
