### PR TITLE
speed up mock building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ RUN usermod -a -G mock builder
 
 VOLUME ["/rpmbuild"]
 
+# create mock cache on external volume to speed up build
+RUN install -g mock -m 2775 -d /rpmbuild/cache/mock
+RUN echo "config_opts['cache_topdir'] = '/rpmbuild/cache/mock'" >> /etc/mock/site-defaults.cfg
+
 ADD ./build-rpm.sh /build-rpm.sh
 RUN chmod +x /build-rpm.sh
 #RUN setcap cap_sys_admin+ep /usr/sbin/mock

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ chown -R 1000:1000 /tmp/rpmbuild
 ```
 In this folder you can put the src.rpms to rebuild.
 
+This folder will also store mock cache directories that allow to speed up repeated build
+
 ## Execute the container to build RPMs
 
 To execute the docker container and rebuild RPMs four SRPMs you can run it in this way:

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -9,6 +9,10 @@ if [ -z "$MOCK_CONFIG" ]; then
         echo "MOCK_CONFIG is empty. Should bin one of: "
         ls -l $MOCK_CONF_FOLDER
 fi
+if [ ! -f "${MOCK_CONF_FOLDER}/${MOCK_CONFIG}.cfg" ]; then
+        echo "MOCK_CONFIG is invalid. Should bin one of: "
+        ls -l $MOCK_CONF_FOLDER
+fi
 if [ -z "$SOURCE_RPM" ] && [ -z "$SPEC_FILE" ]; then
         echo "You need to provide the src.rpm or spec file to build"
         echo "Set SOURCE_RPM or SPEC_FILE environment variables"
@@ -30,6 +34,7 @@ if [ ! -z "$HTTP_PROXY" ] || [ ! -z "$http_proxy" ]; then
         sed s/\\[main\\]/\[main\]\\\nproxy=$TEMP_PROXY/g /tmp/$MOCK_CONFIG.cfg > /etc/mock/$MOCK_CONFIG.cfg
 fi
 
+OUTPUT_FOLDER=${OUTPUT_FOLDER}/${MOCK_CONFIG}
 if [ ! -d "$OUTPUT_FOLDER" ]; then
         mkdir -p $OUTPUT_FOLDER
 else
@@ -41,6 +46,7 @@ echo "      MOCK_CONFIG:    $MOCK_CONFIG"
 #Priority to SOURCE_RPM if both source and spec file env variable are set
 if [ ! -z "$SOURCE_RPM" ]; then
         echo "      SOURCE_RPM:     $SOURCE_RPM"
+        echo "      OUTPUT_FOLDER:  $OUTPUT_FOLDER"
         echo "========================================================================"
         $MOCK_BIN -r $MOCK_CONFIG --rebuild $MOUNT_POINT/$SOURCE_RPM --resultdir=$OUTPUT_FOLDER
 elif [ ! -z "$SPEC_FILE" ]; then
@@ -50,9 +56,11 @@ elif [ ! -z "$SPEC_FILE" ]; then
         fi
         echo "      SPEC_FILE:     $SPEC_FILE"
         echo "      SOURCES:       $SOURCES"
+        echo "      OUTPUT_FOLDER: $OUTPUT_FOLDER"
         echo "========================================================================"
-        $MOCK_BIN -r $MOCK_CONFIG --buildsrpm --spec=$MOUNT_POINT/$SPEC_FILE --sources=$MOUNT_POINT/$SOURCES --resultdir=$OUTPUT_FOLDER
-        $MOCK_BIN -r $MOCK_CONFIG --rebuild $(find $OUTPUT_FOLDER -type f -name "*.src.rpm") --resultdir=$OUTPUT_FOLDER
+        # do not cleanup chroot between both mock calls as 1st does not alter it
+        $MOCK_BIN -r $MOCK_CONFIG --buildsrpm --spec=$MOUNT_POINT/$SPEC_FILE --sources=$MOUNT_POINT/$SOURCES --resultdir=$OUTPUT_FOLDER --no-cleanup-after
+        $MOCK_BIN -r $MOCK_CONFIG --rebuild $(find $OUTPUT_FOLDER -type f -name "*.src.rpm") --resultdir=$OUTPUT_FOLDER --no-clean
 fi
 
 echo "Build finished. Check results inside the mounted volume folder."


### PR DESCRIPTION
Hello Marco

I found your project by accident ;-) , searching around docker and mock

Here is a patch that speed up building by storing mock caches outside container.
This also lower containers disk consumption

Regards, and see you soon

Laurent
