### PR TITLE
Defines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ MAINTAINER Marco Mornati <marco@mornati.net>
 
 RUN yum clean all
 RUN yum -y update
-RUN yum -y insall epel-release
+RUN yum -y install epel-release
 
 #Install Mock Package
-RUN yum -y install mock 
+RUN yum -y install mock
 
 #Configure users
 RUN useradd -u 1000 builder
@@ -22,6 +22,7 @@ ADD ./build-rpm.sh /build-rpm.sh
 RUN chmod +x /build-rpm.sh
 #RUN setcap cap_sys_admin+ep /usr/sbin/mock
 
-USER builder
+USER root
 ENV HOME /home/builder
 CMD ["/build-rpm.sh"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ADD ./build-rpm.sh /build-rpm.sh
 RUN chmod +x /build-rpm.sh
 #RUN setcap cap_sys_admin+ep /usr/sbin/mock
 
-USER root
+USER builder
 ENV HOME /home/builder
 CMD ["/build-rpm.sh"]
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ If you don't have the source RPMs yet, but you get spec file + sources, to build
 docker run --cap-add=SYS_ADMIN -d -e MOCK_CONFIG=epel-6-i386 -e SOURCES=SOURCES/git-2.3.0.tar.gz -e SPEC_FILE=SPECS/git.spec -v /tmp/rpmbuild:/rpmbuild mmornati/mockrpmbuilder
 ```
 
+The below line gives an example of defines configurations. If you have your spec file which takes defines you can configure them in the environment variable as below. The sytax is DEFINE=VALUE it will then be converted to --define 'DEFINE VALUE' instead. You can provide multiple defines by separating them by spaces. 
+
+```bash
+docker run --cap-add=SYS_ADMIN -d -e MOCK_CONFIG=epel-6-i386 -e SOURCES=SOURCES/git-2.3.0.tar.gz -e SPEC_FILE=SPECS/git.spec -e MOCK_DEFINES="VERSION=1 RELEASE=12 ANYTHING_ELSE=1" -v /tmp/rpmbuild:/rpmbuild mmornati/mockrpmbuilder
+```
 It is important to know:
 
 * With spec file the build process could be long. The reason is that mock is invoked twice: the first to build SRPM the second to build all other RPMS.

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -92,11 +92,13 @@ elif [ ! -z "$SPEC_FILE" ]; then
           echo "$MOCK_BIN $DEFINE_CMD -r $MOCK_CONFIG --buildsrpm --spec=$MOUNT_POINT/$SPEC_FILE --sources=$MOUNT_POINT/$SOURCES --resultdir=$OUTPUT_FOLDER" > $OUTPUT_FOLDER/script-test.sh
           echo "$MOCK_BIN $DEFINE_CMD -r $MOCK_CONFIG --rebuild \$(find $OUTPUT_FOLDER -type f -name \"*.src.rpm\") --resultdir=$OUTPUT_FOLDER" >> $OUTPUT_FOLDER/script-test.sh
         fi
-        chmod 755 $OUTPUT_FOLDER/script-test.sh
-        $OUTPUT_FOLDER/script-test.sh
 fi
+
+chmod 755 $OUTPUT_FOLDER/script-test.sh
+$OUTPUT_FOLDER/script-test.sh
 
 rm $OUTPUT_FOLDER/script-test.sh
 
 echo "Build finished. Check results inside the mounted volume folder."
+
 

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -1,10 +1,22 @@
 #!/bin/bash
-
 MOCK_BIN=/usr/bin/mock
 MOCK_CONF_FOLDER=/etc/mock
 MOUNT_POINT=/rpmbuild
 OUTPUT_FOLDER=$MOUNT_POINT/output
 CACHE_FOLDER=$MOUNT_POINT/cache/mock
+MOCK_DEFINES=($MOCK_DEFINES) # convert strings into array items
+DEF_SIZE=${#MOCK_DEFINES[@]}
+
+if [ $DEF_SIZE -gt 0 ];
+then
+  for ((i=0; i<$DEF_SIZE; i++));
+  do
+    #MOCK_DEFINES{$i}=$(echo ${MOCK_DEFINES[$i]} |sed 's/=/ /g')
+    DEFINE_CMD+="--define '$(echo ${MOCK_DEFINES[$i]} |sed 's/=/ /g')' "
+  done
+fi
+
+#$DEFINE_CMD=$(printf %s $DEFINE_CMD)
 
 if [ -z "$MOCK_CONFIG" ]; then
         echo "MOCK_CONFIG is empty. Should bin one of: "
@@ -58,11 +70,9 @@ if [ ! -z "$SOURCE_RPM" ]; then
         echo "      OUTPUT_FOLDER:  $OUTPUT_FOLDER"
         echo "========================================================================"
         if [ ! -z "$NO_CLEANUP" ]; then
-          echo "$MOCK_BIN -r $MOCK_CONFIG --rebuild $MOUNT_POINT/$SOURCE_RPM --resultdir=$OUTPUT_FOLDER --no-clean"
-          $MOCK_BIN -r $MOCK_CONFIG --rebuild $MOUNT_POINT/$SOURCE_RPM --resultdir=$OUTPUT_FOLDER --no-clean
+          echo "$MOCK_BIN $DEFINE_CMD -r $MOCK_CONFIG --rebuild $MOUNT_POINT/$SOURCE_RPM --resultdir=$OUTPUT_FOLDER --no-clean" > $OUTPUT_FOLDER/script-test.sh
         else
-          echo "$MOCK_BIN -r $MOCK_CONFIG --rebuild $MOUNT_POINT/$SOURCE_RPM --resultdir=$OUTPUT_FOLDER"
-          $MOCK_BIN -r $MOCK_CONFIG --rebuild $MOUNT_POINT/$SOURCE_RPM --resultdir=$OUTPUT_FOLDER
+          echo "$MOCK_BIN $DEFINE_CMD -r $MOCK_CONFIG --rebuild $MOUNT_POINT/$SOURCE_RPM --resultdir=$OUTPUT_FOLDER" > $OUTPUT_FOLDER/script-test.sh
         fi
 elif [ ! -z "$SPEC_FILE" ]; then
         if [ -z "$SOURCES" ]; then
@@ -72,19 +82,21 @@ elif [ ! -z "$SPEC_FILE" ]; then
         echo "      SPEC_FILE:     $SPEC_FILE"
         echo "      SOURCES:       $SOURCES"
         echo "      OUTPUT_FOLDER: $OUTPUT_FOLDER"
+        echo "      MOCK_DEFINES:  $MOCK_DEFINES"
         echo "========================================================================"
         if [ ! -z "$NO_CLEANUP" ]; then
           # do not cleanup chroot between both mock calls as 1st does not alter it
-          echo "$MOCK_BIN -r $MOCK_CONFIG --buildsrpm --spec=$MOUNT_POINT/$SPEC_FILE --sources=$MOUNT_POINT/$SOURCES --resultdir=$OUTPUT_FOLDER --no-cleanup-after"
-          echo "$MOCK_BIN -r $MOCK_CONFIG --rebuild $(find $OUTPUT_FOLDER -type f -name "*.src.rpm") --resultdir=$OUTPUT_FOLDER --no-clean"
-          $MOCK_BIN -r $MOCK_CONFIG --buildsrpm --spec=$MOUNT_POINT/$SPEC_FILE --sources=$MOUNT_POINT/$SOURCES --resultdir=$OUTPUT_FOLDER --no-cleanup-after
-          $MOCK_BIN -r $MOCK_CONFIG --rebuild $(find $OUTPUT_FOLDER -type f -name "*.src.rpm") --resultdir=$OUTPUT_FOLDER --no-clean
+          echo "$MOCK_BIN $DEFINE_CMD -r $MOCK_CONFIG --buildsrpm --spec=$MOUNT_POINT/$SPEC_FILE --sources=$MOUNT_POINT/$SOURCES --resultdir=$OUTPUT_FOLDER --no-cleanup-after" > $OUTPUT_FOLDER/script-test.sh
+          echo "$MOCK_BIN $DEFINE_CMD -r $MOCK_CONFIG --rebuild \$(find $OUTPUT_FOLDER -type f -name \"*.src.rpm\") --resultdir=$OUTPUT_FOLDER --no-clean" >> $OUTPUT_FOLDER/script-test.sh
         else
-          echo "$MOCK_BIN -r $MOCK_CONFIG --buildsrpm --spec=$MOUNT_POINT/$SPEC_FILE --sources=$MOUNT_POINT/$SOURCES --resultdir=$OUTPUT_FOLDER"
-          echo "$MOCK_BIN -r $MOCK_CONFIG --rebuild $(find $OUTPUT_FOLDER -type f -name "*.src.rpm") --resultdir=$OUTPUT_FOLDER"
-          $MOCK_BIN -r $MOCK_CONFIG --buildsrpm --spec=$MOUNT_POINT/$SPEC_FILE --sources=$MOUNT_POINT/$SOURCES --resultdir=$OUTPUT_FOLDER
-          $MOCK_BIN -r $MOCK_CONFIG --rebuild $(find $OUTPUT_FOLDER -type f -name "*.src.rpm") --resultdir=$OUTPUT_FOLDER
+          echo "$MOCK_BIN $DEFINE_CMD -r $MOCK_CONFIG --buildsrpm --spec=$MOUNT_POINT/$SPEC_FILE --sources=$MOUNT_POINT/$SOURCES --resultdir=$OUTPUT_FOLDER" > $OUTPUT_FOLDER/script-test.sh
+          echo "$MOCK_BIN $DEFINE_CMD -r $MOCK_CONFIG --rebuild \$(find $OUTPUT_FOLDER -type f -name \"*.src.rpm\") --resultdir=$OUTPUT_FOLDER" >> $OUTPUT_FOLDER/script-test.sh
         fi
+        chmod 755 $OUTPUT_FOLDER/script-test.sh
+        $OUTPUT_FOLDER/script-test.sh
 fi
 
+rm $OUTPUT_FOLDER/script-test.sh
+
 echo "Build finished. Check results inside the mounted volume folder."
+


### PR DESCRIPTION
Now everything should work. Removed root user from Dockerfile and fixed build script with failed to build source RPMs.

Full description from the previous pull request:
Main script doesn't support define variables. I do work on the single spec files but they build differently depends on the defines I set. Mock has an option to use defines so I added them to the script. However I had to change the way the script runs as by passing an environment variable to docker Mock didn't actually recognising them or rather it did but from some reason it was wrapping them around the single quotes what broke the syntax. I had to use the main script as a helper to generate final temporary script which runs Mock and compiles the package.