### PR TITLE
Allow user builder to set proxy in mock config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN yum -y install mock
 #Configure users
 RUN useradd -u 1000 builder
 RUN usermod -a -G mock builder
+RUN chmod g+w /etc/mock/*.cfg
 
 VOLUME ["/rpmbuild"]
 


### PR DESCRIPTION
Since commit 85467914f57ffec4c6935d5866985bda7d1eb1e1 script is running
under builder user, so it cannot edit file in /etc/mock which
belongs to root:mock, to set the http_proxy
As builder user is member of mock group, /etc/mock/*.cfg should be
writable for group mock.