### PR TITLE
Shellcheck & Lint & make Gitlab Cache friendly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos8.3.2011
+FROM fedora:latest
 LABEL "maintainer"="Marco Mornati <marco@mornati.net>"
 LABEL "com.github.actions.name"="RPM Builder"
 LABEL "com.github.actions.description"="Build RPM using RedHat Mock"
@@ -6,27 +6,20 @@ LABEL "com.github.actions.icon"="pocket"
 LABEL "com.github.actions.color"="green"
 
 RUN dnf -y --setopt="tsflags=nodocs" update && \
-	dnf -y --setopt="tsflags=nodocs" install epel-release && \
-	dnf -y --setopt="tsflags=nodocs" install mock rpm-sign expect && \
+	dnf -y --setopt="tsflags=nodocs" install rpmdevtools mock rpm-sign \
+	expect && \
 	dnf clean all && \
-	rm -rf /var/cache/dnf/
+	rm -rf "/var/cache/dnf"
 
-#Configure users
-RUN useradd -u 1000 -G mock builder && \
-	chmod g+w /etc/mock/*.cfg
-
-VOLUME ["/rpmbuild"]
+RUN useradd mockbuilder && \
+    usermod -a -G mock mockbuilder && \
+    chmod g+w /etc/mock/*.cfg
 
 ONBUILD COPY mock /etc/mock
 
-# create mock cache on external volume to speed up build
-RUN install -g mock -m 2775 -d /rpmbuild/cache/mock
-RUN echo "config_opts['cache_topdir'] = '/rpmbuild/cache/mock'" >> /etc/mock/site-defaults.cfg
-
-ADD ./build-rpm.sh /build-rpm.sh
+COPY ./build-rpm.sh /build-rpm.sh
 RUN chmod +x /build-rpm.sh
-#RUN setcap cap_sys_admin+ep /usr/sbin/mock
-ADD ./rpm-sign.exp /rpm-sign.exp
+COPY ./rpm-sign.exp /rpm-sign.exp
 RUN chmod +x /rpm-sign.exp
 
 CMD ["/build-rpm.sh"]

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ Build RPMs using the Mock Project (for any platform)
 
 ## Create working directory
 
-To allow the import/export of created RPMs you need to create a docker volume and allow the read/write rights (or add owner) to the user builder(uid:1000).
+To allow the import/export of created RPMs you need to create a docker volume
+and allow the read/write rights (or add owner) to the user builder(uid:1000).
 
-> NOTE: On Mac OSx the `chown` is not needed. Docker it will be able to build directly using your Mac default/admin user. 
+> NOTE: On Mac OSx the `chown` is not needed. Docker it will be able to build directly using your Mac default/admin user.
 
 ```bash
 mkdir /Users/mmornati/rpmbuild
@@ -15,11 +16,13 @@ chown -R 1000:1000 /Users/mmornati/rpmbuild
 ```
 In this folder you can put the src.rpms to rebuild.
 
-This folder will also store mock cache directories that allow to speed up repeated build
+This folder will also store mock cache directories that allow to speed up
+repeated build
 
 ## Build the container locally
 
-First you need to build the container, which we will call "mmornati/mock-rpmbuilder":
+First you need to build the container, which we will call
+"mmornati/mock-rpmbuilder":
 
 ```bash
 docker build -t mmornati/mock-rpmbuilder <path to git repo>
@@ -27,7 +30,9 @@ docker build -t mmornati/mock-rpmbuilder <path to git repo>
 
 ## Download latest version of the image from Docker Hub
 
-This git repository are actually linked with Docker Hub Automatic build system. Any new commit here will produce a new version build. You can now simply pull the latest image build.
+This git repository are actually linked with Docker Hub Automatic build system.
+Any new commit here will produce a new version build. You can now simply pull
+the latest image build.
 
 ```bash
 docker pull mmornati/mock-rpmbuilder
@@ -35,29 +40,55 @@ docker pull mmornati/mock-rpmbuilder
 
 ## Execute the container to build RPMs
 
-To execute the docker container and rebuild RPMs four SRPMs you can run it in this way:
+To execute the docker container and rebuild RPMs four SRPMs you can run it in
+this way:
 
 ```bash
-docker run --cap-add=SYS_ADMIN -d -e MOCK_CONFIG=epel-8-aarch64 -e SOURCE_RPM=git-2.3.0-1.el7.centos.src.rpm -v /Users/mmornati/rpmbuild:/rpmbuild mmornati/mock-rpmbuilder
+docker run --rm --privileged=true \
+--volume="/Users/mmornati/rpmbuild:/rpmbuild" -e MOUNT_POINT="/rpmbuild" \
+-e MOCK_CONFIG="epel-8-aarch64" \
+-e SOURCE_RPM="git-2.3.0-1.el7.centos.src.rpm" mmornati/mock-rpmbuilder
 ```
 
 If you don't have the source RPMs yet, but you get spec file + sources, to build RPMs you need to start the docker container in this way:
 
 ```bash
-docker run --cap-add=SYS_ADMIN -d -e GITHUB_WORKSPACE=/rpmbuild -e MOCK_CONFIG=epel-8-aarch64 -e SOURCES=SOURCES/git-2.3.0.tar.gz -e SPEC_FILE=SPECS/git.spec -v /Users/mmornati/rpmbuild:/rpmbuild mmornati/mock-rpmbuilder
+docker run --rm --privileged=true \
+--volume="/Users/mmornati/rpmbuild:/rpmbuild" -e MOUNT_POINT="/rpmbuild" \
+-e MOCK_CONFIG="epel-8-aarch64" -e SOURCES="SOURCES/git-2.3.0.tar.gz" \
+-e SPEC_FILE="SPECS/git.spec" mmornati/mock-rpmbuilder
 ```
 
-The below line gives an example of defines configurations. If you have your spec file which takes defines you can configure them in the environment variable as below. The sytax is DEFINE=VALUE it will then be converted to --define 'DEFINE VALUE' instead. You can provide multiple defines by separating them by spaces. 
+In case, when sources is not availables, but can be download, just omit the
+SOURCE variable, rpmbuild will try to download it before mock build
 
 ```bash
-docker run --cap-add=SYS_ADMIN -d -e GITHUB_WORKSPACE=/rpmbuild -e MOCK_CONFIG=epel-8-aarch64 -e SOURCES=SOURCES/git-2.3.0.tar.gz -e SPEC_FILE=SPECS/git.spec -e MOCK_DEFINES="VERSION=1 RELEASE=12 ANYTHING_ELSE=1" -v /Users/mmornati/rpmbuild:/rpmbuild mmornati/mock-rpmbuilder
+docker run --rm --privileged=true \
+--volume="/Users/mmornati/rpmbuild:/rpmbuild" -e MOUNT_POINT="/rpmbuild" \
+-e MOCK_CONFIG="epel-8-aarch64" -e SPEC_FILE="SPECS/git.spec" \
+mmornati/mock-rpmbuilder
 ```
+
+The below line gives an example of defines configurations. If you have your spec file which takes defines you can configure them in the environment variable as below. The sytax is DEFINE=VALUE it will then be converted to --define 'DEFINE VALUE' instead. You can provide multiple defines by separating them by spaces.
+
+```bash
+docker run --rm --privileged=true \
+--volume="/Users/mmornati/rpmbuild:/rpmbuild" -e MOUNT_POINT="/rpmbuild" \
+-e MOCK_CONFIG="epel-8-aarch64" -e SOURCES="SOURCES/git-2.3.0.tar.gz" \
+-e SPEC_FILE="SPECS/git.spec" \
+-e MOCK_DEFINES="VERSION=1 RELEASE=12 ANYTHING_ELSE=1" mmornati/mock-rpmbuilder
+```
+
 It is important to know:
 
-* With spec file the build process could be long. The reason is that mock is invoked twice: the first to build SRPM the second to build all other RPMS.
-* The folders specified for SPEC_FILE, SOURCES and SOURCE_RPM env variables are relative to your mount point. This means if files are at the root of mount point you need to specify only the file name, otherwise the subfolder should be added too. (See SOURCES in my example)
+* With spec file the build process could be long. The reason is that mock is
+invoked twice: the first to build SRPM the second to build all other RPMS
+* The folders specified for SPEC_FILE, SOURCES and SOURCE_RPM env variables are relative to your mount point. This means if files are at the root of mount point
+you need to specify only the file name, otherwise the subfolder should be added
+too (See SOURCES in my example)
 
-> NB: It's important to run the container with privileged rights because mock needs the "unshare" system call to create a
+> NB: It's important to run the container with privileged rights because mock
+> needs the "unshare" system call to create a
 > new mountpoint inside the process.
 > Withour this you will get this error:
 >
@@ -69,65 +100,37 @@ It is important to know:
 ## Execute without cleanup of Mock CHROOT folder
 
 To speedup build, as suggested by [llicour](https://github.com/llicour), we can prevent the cleanup of the Mock chroot folder.
-We can enable it simply by passing a new parameter (NO_CLEANUP) to the build command:
+We can enable it simply by passing a new parameter (NO_CLEANUP) to the build
+command:
 
 ```bash
-docker run --cap-add=SYS_ADMIN -d -e GITHUB_WORKSPACE=/rpmbuild -e MOCK_CONFIG=epel-8-aarch64 -e SOURCE_RPM=git-2.3.0-1.el7.centos.src.rpm -e NO_CLEANUP=true -v /Users/mmornati/rpmbuild:/rpmbuild mmornati/mock-rpmbuilder
+docker run --rm --privileged=true \
+--volume="/Users/mmornati/rpmbuild:/rpmbuild" -e MOUNT_POINT="/rpmbuild" \
+-e MOCK_CONFIG="epel-8-aarch64" -e NO_CLEANUP="true" \
+-e SOURCES="SOURCES/git-2.3.0.tar.gz" -e SPEC_FILE="SPECS/git.spec" \
+mmornati/mock-rpmbuilder
 ```
 
 ## Allowed configurations
 
-```
-amazonlinux-2-aarch64     fedora-33-i386          mageia-cauldron-aarch64
-amazonlinux-2-x86_64      fedora-33-ppc64le       mageia-cauldron-armv7hl
-centos-7-aarch64          fedora-33-s390x         mageia-cauldron-i586
-centos-7-ppc64            fedora-33-x86_64        mageia-cauldron-x86_64
-centos-7-ppc64le          fedora-34-aarch64       openmandriva-4.1-aarch64
-centos-7-x86_64           fedora-34-armhfp        openmandriva-4.1-armv7hnl
-centos-8-aarch64          fedora-34-i386          openmandriva-4.1-i686
-centos-8-ppc64le          fedora-34-ppc64le       openmandriva-4.1-x86_64
-centos-8-x86_64           fedora-34-s390x         openmandriva-cooker-aarch64
-centos-stream-8-aarch64   fedora-34-x86_64        openmandriva-cooker-armv7hnl
-centos-stream-8-ppc64le   fedora-35-aarch64       openmandriva-cooker-i686
-centos-stream-8-x86_64    fedora-35-armhfp        openmandriva-cooker-x86_64
-custom-1-aarch64          fedora-35-i386          openmandriva-rolling-aarch64
-custom-1-armhfp           fedora-35-ppc64le       openmandriva-rolling-armv7hnl
-custom-1-i386             fedora-35-s390x         openmandriva-rolling-i686
-custom-1-ppc64            fedora-35-x86_64        openmandriva-rolling-x86_64
-custom-1-ppc64le          fedora-eln-aarch64      opensuse-leap-15.1-aarch64
-custom-1-s390             fedora-eln-i386         opensuse-leap-15.1-x86_64
-custom-1-s390x            fedora-eln-ppc64le      opensuse-leap-15.2-aarch64
-custom-1-x86_64           fedora-eln-s390x        opensuse-leap-15.2-x86_64
-default                   fedora-eln-x86_64       opensuse-tumbleweed-aarch64
-epel-7-aarch64            fedora-rawhide-aarch64  opensuse-tumbleweed-i586
-epel-7-ppc64              fedora-rawhide-armhfp   opensuse-tumbleweed-ppc64
-epel-7-ppc64le            fedora-rawhide-i386     opensuse-tumbleweed-ppc64le
-epel-7-x86_64             fedora-rawhide-ppc64le  opensuse-tumbleweed-x86_64
-epel-8-aarch64            fedora-rawhide-s390x    rhel-7-aarch64
-epel-8-ppc64le            fedora-rawhide-x86_64   rhel-7-ppc64
-epel-8-x86_64             mageia-7-aarch64        rhel-7-ppc64le
-epelplayground-8-aarch64  mageia-7-armv7hl        rhel-7-s390x
-epelplayground-8-ppc64le  mageia-7-i586           rhel-7-x86_64
-epelplayground-8-x86_64   mageia-7-x86_64         rhel-8-aarch64
-fedora-32-aarch64         mageia-8-aarch64        rhel-8-ppc64le
-fedora-32-armhfp          mageia-8-armv7hl        rhel-8-s390x
-fedora-32-i386            mageia-8-i586           rhel-8-x86_64
-fedora-32-ppc64le         mageia-8-x86_64         rhelepel-8-aarch64
-fedora-32-s390x           mageia-9-aarch64        rhelepel-8-ppc64
-fedora-32-x86_64          mageia-9-armv7hl        rhelepel-8-ppc64le
-fedora-33-aarch64         mageia-9-i586           rhelepel-8-x86_64
-fedora-33-armhfp          mageia-9-x86_64         site-defaults
-```
+See at [mock repo](https://github.com/rpm-software-management/mock/tree/main/mock-core-configs/etc/mock)
+
 
 ## Signing your RPMs with GPG Key
 
 If you want you sign your RPMs, you need to pass some extra parameters
-* Mount the directory with your gpg private key : -v $HOME/.gnupg:/home/rpmbuilder/.gnupg:ro
+* Mount the directory with your gpg private key : -v
+$HOME/.gnupg:/home/rpmbuilder/.gnupg:ro
 * Set the Signature key you want to use : -e SIGNATURE="Corporate Repo Key"
-* Pass the GPG Key passphrase, if needed : -e GPG_PASS="my very secure password". You can put the passphrase in a file and use GPG_PASS="$(cat $PWD/.gpg_pass)"
+* Pass the GPG Key passphrase, if needed : -e GPG_PASS="my very secure password"
+You can put the passphrase in a file and use GPG_PASS="$(cat $PWD/.gpg_pass)"
 
-```
-docker run --cap-add=SYS_ADMIN -d -e GITHUB_WORKSPACE=/rpmbuild -e MOCK_CONFIG=epel-8-aarch64 -e SOURCE_RPM=git-2.3.0-1.el7.centos.src.rpm -v /Users/mmornati/rpmbuild:/rpmbuild -e SIGNATURE="Corporate Repo Key" -e GPG_PASS="$(cat $PWD/.gpg_pass)" -v $HOME/.gnupg:/home/builder/.gnupg:ro mmornati/mock-rpmbuilder
+```basb
+docker run --cap-add=SYS_ADMIN -d -e MOUNT_POINT="/rpmbuild" \
+-e MOCK_CONFIG=epel-8-aarch64 -e SOURCE_RPM=git-2.3.0-1.el7.centos.src.rpm \
+-v /Users/mmornati/rpmbuild:/rpmbuild -e SIGNATURE="Corporate Repo Key" \
+-e GPG_PASS="$(cat $PWD/.gpg_pass)" -v $HOME/.gnupg:/home/builder/.gnupg:ro \
+mmornati/mock-rpmbuilder
 ```
 
 ## BETA: Build on GitHub Actions
@@ -145,6 +148,7 @@ action "Build RPM" {
     SPEC_FILE = "git.spec"
     SOURCES = "git-2.3.0.tar.gz"
     MOCK_CONFIG = "epel-8-aarch64"
+    MOUNT_POINT = "${GITHUB_WORKSPACE}"
   }
 }
 ```
@@ -196,7 +200,8 @@ totale 188
 
 ## Output
 
-If all worked well, you should have all the RPMs (source + binaries) availables in the configured output folder:
+If all worked well, you should have all the RPMs (source + binaries) availables
+in the configured output folder:
 
 ```bash
 [root@server ~]# ll /Users/mmornati/rpmbuild/output/
@@ -219,9 +224,11 @@ totale 28076
 ```
 
 ## Contributions
-Updated and fixed with contributions by [csmart](https://github.com/csmart/docker-mock-rpmbuilder/commit/c3f47343efd4484131af5fd254f3e51cb7414a78) and [llicour](https://github.com/llicour/docker-mock-rpmbuilder/commit/6a5b169860b3b42f10a7c7771d1342dd7c78359b)
+Updated and fixed with contributions by [csmart](https://github.com/csmart/docker-mock-rpmbuilder/commit/c3f47343efd4484131af5fd254f3e51cb7414a78) and
+[llicour](https://github.com/llicour/docker-mock-rpmbuilder/commit/6a5b169860b3b42f10a7c7771d1342dd7c78359b)
 
 ## Docker HUB
-This repository is automatically linked to Docker Hub. [https://hub.docker.com/r/mmornati/mock-rpmbuilder/](https://hub.docker.com/r/mmornati/mock-rpmbuilder/).
+This repository is automatically linked to Docker Hub
+[https://hub.docker.com/r/mmornati/mock-rpmbuilder/](https://hub.docker.com/r/mmornati/mock-rpmbuilder/).
 
 Any new commit and contribution will automatically force a build on DockerHub to have the latest version of the container ready to use.

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -1,121 +1,159 @@
-#!/bin/bash
-# exit when any command fails
+#!/usr/bin/bash
 set -e
-MOCK_BIN=/usr/bin/mock
-MOCK_CONF_FOLDER=/etc/mock
-MOUNT_POINT=$GITHUB_WORKSPACE
-OUTPUT_FOLDER=$MOUNT_POINT/output
-CACHE_FOLDER=$MOUNT_POINT/cache/mock
-MOCK_DEFINES=($MOCK_DEFINES) # convert strings into array items
-DEF_SIZE=${#MOCK_DEFINES[@]}
 
-if [ $DEF_SIZE -gt 0 ];
+MOCK_BIN="/usr/bin/mock"
+MOCK_CONF_FOLDER="/etc/mock"
+OUTPUT_FOLDER="${MOUNT_POINT}/output"
+CACHE_FOLDER="${MOUNT_POINT}/cache"
+MOCK_DEFINES=($MOCK_DEFINES) # convert strings into array items
+DEF_SIZE="${#MOCK_DEFINES[@]}"
+
+if [ "${DEF_SIZE}" -gt 0 ];
 then
-  for ((i=0; i<$DEF_SIZE; i++));
+  for ((i=0; i < DEF_SIZE; i++));
   do
-    #MOCK_DEFINES{$i}=$(echo ${MOCK_DEFINES[$i]} |sed 's/=/ /g')
-    DEFINE_CMD+="--define '$(echo ${MOCK_DEFINES[$i]} |sed 's/=/ /g')' "
+    DEFINE_CMD+="--define '$(echo ${MOCK_DEFINES[$i]} | sed 's/=/ /g')' "
   done
 fi
 
 #$DEFINE_CMD=$(printf %s $DEFINE_CMD)
-if [ -z "$MOCK_CONFIG" ]; then
-        echo "MOCK_CONFIG is empty. Should bin one of: "
-        ls -l $MOCK_CONF_FOLDER
-fi
-if [ ! -f "${MOCK_CONF_FOLDER}/${MOCK_CONFIG}.cfg" ]; then
-        echo "MOCK_CONFIG is invalid. Should bin one of: "
-        ls -l $MOCK_CONF_FOLDER
-fi
-if [ -z "$SOURCE_RPM" ] && [ -z "$SPEC_FILE" ]; then
-        echo "You need to provide the src.rpm or spec file to build"
-        echo "Set SOURCE_RPM or SPEC_FILE environment variables"
-        exit 1
-fi
-if [ ! -z "$NO_CLEANUP" ]; then
-        echo "WARNING: Disabling clean up of the build folder after build."
+if [ -z "${MOCK_CONFIG}" ]
+  then
+    echo "MOCK_CONFIG is empty. Should bin one of: "
+    ls -l "${MOCK_CONF_FOLDER}"
+elif [ ! -f "${MOCK_CONF_FOLDER}/${MOCK_CONFIG}.cfg" ]
+  then
+    echo "MOCK_CONFIG is invalid. Should bin one of: "
+    ls -l "${MOCK_CONF_FOLDER}"
+elif [ -z "${SOURCE_RPM}" ] && [ -z "${SPEC_FILE}" ]
+  then
+    echo "Please provide the src.rpm or spec file to build"
+    echo "Set SOURCE_RPM or SPEC_FILE environment variables"
+    exit 1
 fi
 
-#If proxy env variable is set, add the proxy value to the configuration file
-if [ ! -z "$HTTP_PROXY" ] || [ ! -z "$http_proxy" ]; then
-        TEMP_PROXY=""
-        if [ ! -z "$HTTP_PROXY" ]; then
-                TEMP_PROXY=$(echo $HTTP_PROXY | sed s/\\//\\\\\\//g)
-        fi
-        if [ ! -z "$http_proxy" ]; then
-                TEMP_PROXY=$(echo $http_proxy | sed s/\\//\\\\\\//g)
-        fi
-
-        echo "Configuring http proxy to the mock build file to: $TEMP_PROXY"
-        cp /etc/mock/$MOCK_CONFIG.cfg /tmp/$MOCK_CONFIG.cfg
-        sed s/\\[main\\]/\[main\]\\\nproxy=$TEMP_PROXY/g /tmp/$MOCK_CONFIG.cfg > /etc/mock/$MOCK_CONFIG.cfg
+if [ -n "${NO_CLEANUP}" ]
+  then
+    echo "WARNING: Disabling clean up of the build folder after build"
 fi
 
-OUTPUT_FOLDER=${OUTPUT_FOLDER}/${MOCK_CONFIG}
-if [ ! -d "$OUTPUT_FOLDER" ]; then
-        mkdir -p $OUTPUT_FOLDER
-        chown -R builder:mock $OUTPUT_FOLDER
+# If proxy env variable is set, add the proxy value to the configuration file
+if [ -n "${HTTP_PROXY}" ] || [ -n "${http_proxy}" ]
+  then
+    TEMP_PROXY=""
+    if [ -n "${HTTP_PROXY}" ]
+      then
+        TEMP_PROXY=$(echo "${HTTP_PROXY}" | sed s/\\//\\\\\\//g)
+    fi
+
+    if [ -n "${http_proxy}" ]
+      then
+        TEMP_PROXY=$(echo "${http_proxy}" | sed s/\\//\\\\\\//g)
+    fi
+
+    echo "Configuring http proxy to the mock build file to: ${TEMP_PROXY}"
+    cp "/etc/mock/${MOCK_CONFIG}.cfg" "/tmp/$MOCK_CONFIG.cfg"
+    sed s/\\[main\\]/\[main\]\\\nproxy="${TEMP_PROXY}"/g \
+"/tmp/${MOCK_CONFIG}.cfg" > "/etc/mock/${MOCK_CONFIG}.cfg"
+
+fi
+
+OUTPUT_FOLDER="${OUTPUT_FOLDER}/${MOCK_CONFIG}"
+
+if [ ! -d "${OUTPUT_FOLDER}" ]
+  then
+    mkdir -p "${OUTPUT_FOLDER}"
+    chown -R mockbuilder:mock "${OUTPUT_FOLDER}"
 else
-        rm -f $OUTPUT_FOLDER/*
+  rm -f "${OUTPUT_FOLDER}"/*
 fi
 
-if [ ! -d "$CACHE_FOLDER" ]; then
-        mkdir -p $CACHE_FOLDER
-        chown -R builder:mock $CACHE_FOLDER
+if [ ! -d "${CACHE_FOLDER}" ]; then
+        mkdir -p "${CACHE_FOLDER}"
+        chown -R mockbuilder:mock "${CACHE_FOLDER}"
+        MOCK_CONFIG_OPTS="--config-opts=cache_topdir=${CACHE_FOLDER}"
 fi
 
 echo "=> Building parameters:"
-echo "========================================================================"
-echo "      MOCK_CONFIG:    $MOCK_CONFIG"
-#Priority to SOURCE_RPM if both source and spec file env variable are set
-if [ ! -z "$SOURCE_RPM" ]; then
-        echo "      SOURCE_RPM:     $SOURCE_RPM"
-        echo "      OUTPUT_FOLDER:  $OUTPUT_FOLDER"
-        echo "========================================================================"
-        if [ ! -z "$NO_CLEANUP" ]; then
-          echo "$MOCK_BIN $DEFINE_CMD -r $MOCK_CONFIG --rebuild $MOUNT_POINT/$SOURCE_RPM --resultdir=$OUTPUT_FOLDER --no-clean" > $OUTPUT_FOLDER/script-test.sh
-        else
-          echo "$MOCK_BIN $DEFINE_CMD -r $MOCK_CONFIG --rebuild $MOUNT_POINT/$SOURCE_RPM --resultdir=$OUTPUT_FOLDER" > $OUTPUT_FOLDER/script-test.sh
-        fi
-elif [ ! -z "$SPEC_FILE" ]; then
-        if [ -z "$SOURCES" ]; then
-                echo "WARNING: The SOURCES env variable pointing to folder or sources file was not specified. $SPEC_FILE will need to profied it's own Source."
-        fi
-        echo "      SPEC_FILE:     $SPEC_FILE"
-        echo "      SOURCES:       $SOURCES"
-        echo "      OUTPUT_FOLDER: $OUTPUT_FOLDER"
-        echo "      MOCK_DEFINES:  ${MOCK_DEFINES[@]}"
-        echo "========================================================================"
+echo "================================================================="
+echo "      MOCK_CONFIG:   ${MOCK_CONFIG}"
 
-        BUILD_COMMAND="$MOCK_BIN $DEFINE_CMD -r $MOCK_CONFIG --buildsrpm --spec=$MOUNT_POINT/$SPEC_FILE --resultdir=$OUTPUT_FOLDER"
-        REBUILD_COMMAND="$MOCK_BIN $DEFINE_CMD -r $MOCK_CONFIG --rebuild \$(find $OUTPUT_FOLDER -type f -name \"*.src.rpm\") --resultdir=$OUTPUT_FOLDER"
+# Priority to SOURCE_RPM if both source and spec file env variable are set
+if [ -n "${SOURCE_RPM}" ]
+  then
+    echo "      SOURCE_RPM:     ${SOURCE_RPM}"
+    echo "      OUTPUT_FOLDER:  ${OUTPUT_FOLDER}"
+    echo "================================================================="
 
-        if [ ! -z "$SOURCES" ]; then
-          BUILD_COMMAND="$BUILD_COMMAND --sources=$MOUNT_POINT/$SOURCES"
+    if [ -n "${NO_CLEANUP}" ]
+      then
+        echo "${MOCK_BIN} ${MOCK_CONFIG_OPTS} ${DEFINE_CMD} -r ${MOCK_CONFIG} \
+--rebuild ${MOUNT_POINT}/${SOURCE_RPM} --resultdir=${OUTPUT_FOLDER} \
+--no-clean" > "${OUTPUT_FOLDER}/build-script.sh"
+    else
+      echo "${MOCK_BIN} ${MOCK_CONFIG_OPTS} ${DEFINE_CMD} -r ${MOCK_CONFIG} \
+--rebuild ${MOUNT_POINT}/${SOURCE_RPM} --resultdir=${OUTPUT_FOLDER}" > \
+"${OUTPUT_FOLDER}/build-script.sh"
+    fi
+
+elif [ -n "${SPEC_FILE}" ]
+  then
+    if [ -z "${SOURCES}" ]
+      then
+        SOURCES="sources"
+        mkdir -p "${MOUNT_POINT}/${SOURCES}"
+    fi
+
+        echo "      SPEC_FILE:     ${SPEC_FILE}"
+        echo "      SOURCES:       ${SOURCES}"
+        echo "      OUTPUT_FOLDER: ${OUTPUT_FOLDER}"
+        echo "      MOCK_DEFINES:  ${MOCK_DEFINES[*]}"
+        echo "================================================================="
+
+        BUILD_COMMAND="${MOCK_BIN} ${MOCK_CONFIG_OPTS} ${DEFINE_CMD} -r \
+${MOCK_CONFIG} --buildsrpm --spec=${MOUNT_POINT}/${SPEC_FILE} \
+--resultdir=${OUTPUT_FOLDER} --sources=${MOUNT_POINT}/${SOURCES}"
+        REBUILD_COMMAND="${MOCK_BIN} ${MOCK_CONFIG_OPTS} ${DEFINE_CMD} -r \
+${MOCK_CONFIG} --rebuild \$(find ${OUTPUT_FOLDER} -type f -name \"*.src.rpm\") \
+--resultdir=${OUTPUT_FOLDER}"
+
+        if [ -n "${NO_CLEANUP}" ]
+          then
+          # do not cleanup chroot between both mock calls as 1st does not alter
+          # it
+            BUILD_COMMAND="${BUILD_COMMAND} --no-cleanup-after"
+            REBUILD_COMMAND="${REBUILD_COMMAND} --no-clean"
         fi
 
-        if [ ! -z "$NO_CLEANUP" ]; then
-          # do not cleanup chroot between both mock calls as 1st does not alter it
-          BUILD_COMMAND="$BUILD_COMMAND --no-cleanup-after"
-          REBUILD_COMMAND="$REBUILD_COMMAND --no-clean"
-        fi
-
-        echo "$BUILD_COMMAND" > $OUTPUT_FOLDER/script-test.sh
-        echo "$REBUILD_COMMAND" >> $OUTPUT_FOLDER/script-test.sh
+        {
+          echo "set -e"
+          echo "${BUILD_COMMAND}"
+          echo "${REBUILD_COMMAND}"
+        } >> "${OUTPUT_FOLDER}/build-script.sh"
 fi
 
-chmod 755 $OUTPUT_FOLDER/script-test.sh
-runuser -l builder -c "sh $OUTPUT_FOLDER/script-test.sh"
+if [[ "${SOURCES}" == "sources" ]]
+  then
+    /usr/bin/rpmbuild --nobuild --define "_topdir ${MOUNT_POINT}/${SOURCES}" \
+--define "_sourcedir ${MOUNT_POINT}/${SOURCES}" \
+--define "source_date_epoch_from_changelog false" \
+--undefine "_disable_source_fetch" "${MOUNT_POINT}/${SPEC_FILE}"
+fi
 
-rm $OUTPUT_FOLDER/script-test.sh
+chmod 755 "${OUTPUT_FOLDER}/build-script.sh"
+sudo -u mockbuilder "${OUTPUT_FOLDER}/build-script.sh" 2> /dev/stderr
 
-if [ ! -z "$SIGNATURE" ]; then
-	echo "%_signature gpg" > $HOME/.rpmmacros
-	echo "%_gpg_name ${SIGNATURE}" >> $HOME/.rpmmacros
-	echo "Signing RPM using ${SIGNATURE} key"
-	find $OUTPUT_FOLDER -type f -name "*.rpm" -exec /rpm-sign.exp {} ${GPG_PASS} \;
+rm "${OUTPUT_FOLDER}/build-script.sh"
+
+if [ -n "${SIGNATURE}" ]
+  then
+    echo "%_signature gpg" > "${HOME}/.rpmmacros"
+    echo "%_gpg_name ${SIGNATURE}" >> "${HOME}/.rpmmacros"
+    echo "Signing RPM using ${SIGNATURE} key"
+    find "${OUTPUT_FOLDER}" -type f -name "*.rpm" -exec /rpm-sign.exp {} \
+"${GPG_PASS}" \;
 else
-	echo "No RPMs signature requested"
+  echo "No RPMs signature requested"
 fi
 
-echo "Build finished. Check results inside the mounted volume folder."
+echo "Build finished. Check results inside 'output' directory"


### PR DESCRIPTION
Hi, the dockerhub `latest` image just doesn't works at 2023
I was invested time to `shellcheck` the build script & remove volume binds

Some changes come from #22, but without spectool. spectool doesn't exit with non-zero exit code when Source impossible to download or another sort of error, see [BZ#2096624](https://bugzilla.redhat.com/show_bug.cgi?id=2096624), it was replaced to `rpmbuild`

When source files failed to download, for example due HTTP 403 or 404 code, error will be produced:

```python
WARNING: Disabling clean up of the build folder after build
=> Building parameters:
=================================================================
      MOCK_CONFIG:   centos-stream-8-aarch64
      SPEC_FILE:     sst.spec
      SOURCES:       Will be downloaded automatically
      OUTPUT_FOLDER: /rpmbuild/output/centos-stream-8-aarch64
      MOCK_DEFINES:
=================================================================
warning: Downloading https://downloadmirror.intel.com/743764/SST_CLI_Linux_1.3.zip to /home/mockbuilder/rpmbuild/SOURCES/SST_CLI_Linux_1.3.zip
curl: (22) The requested URL returned error: 403
error: Couldn't download https://downloadmirror.intel.com/743764/SST_CLI_Linux_1.3.zip
```

When download is successful, mock build will starts as usual:

```python
WARNING: Disabling clean up of the build folder after build
=> Building parameters:
=================================================================
      MOCK_CONFIG:   centos-stream-8-aarch64
      SPEC_FILE:     sst.spec
      SOURCES:       sources
      OUTPUT_FOLDER: /rpmbuild/output/centos-stream-8-aarch64
      MOCK_DEFINES:
=================================================================
warning: Downloading https://sdmsdfwdriver.blob.core.windows.net/files/kba-gcc/drivers-downloads/ka-00085--sst/sst--1-5/sst-cli-linux-rpm--1-5.zip to /rpmbuild/sources/sst-cli-linux-rpm--1-5.zip

RPM build warnings:
    Downloading https://sdmsdfwdriver.blob.core.windows.net/files/kba-gcc/drivers-downloads/ka-00085--sst/sst--1-5/sst-cli-linux-rpm--1-5.zip to /rpmbuild/sources/sst-cli-linux-rpm--1-5.zip
INFO: mock.py version 3.5 starting (python version = 3.11.1, NVR = mock-3.5-1.fc37)...
Start(bootstrap): init plugins
INFO: selinux disabled
Finish(bootstrap): init plugins
Start: init plugins
INFO: selinux disabled
Finish: init plugins
INFO: Signal handler active
Start: run
INFO: Start(/rpmbuild/sst.spec)  Config(centos-stream-8-aarch64)
```

Verified the docker build & Gitlab runner can works with this image

```python
√ docker-mock-rpmbuilder % docker build -t mock .
[+] Building 87.4s (12/12) FINISHED
 => [internal] load build definition from Dockerfile                                                                                    0.0s
 => => transferring dockerfile: 755B                                                                                                    0.0s
 => [internal] load .dockerignore                                                                                                       0.0s
 => => transferring context: 2B                                                                                                         0.0s
 => [internal] load metadata for docker.io/library/fedora:latest                                                                        2.8s
 => CACHED [1/7] FROM docker.io/library/fedora:latest@sha256:3487c98481d1bba7e769cf7bcecd6343c2d383fdd6bed34ec541b6b23ef07664           0.0s
 => [internal] load build context                                                                                                       0.0s
 => => transferring context: 4.93kB                                                                                                     0.0s
 => [2/7] RUN dnf -y --setopt="tsflags=nodocs" update &&     dnf -y --setopt="tsflags=nodocs" install rpmdevtools mock rpm-sign     e  82.9s
 => [3/7] RUN useradd mockbuilder &&     usermod -a -G mock mockbuilder &&     chmod g+w /etc/mock/*.cfg                                0.5s
 => [4/7] COPY ./build-rpm.sh /build-rpm.sh                                                                                             0.0s
 => [5/7] RUN chmod +x /build-rpm.sh                                                                                                    0.1s
 => [6/7] COPY ./rpm-sign.exp /rpm-sign.exp                                                                                             0.0s
 => [7/7] RUN chmod +x /rpm-sign.exp                                                                                                    0.2s
 => exporting to image                                                                                                                  0.9s
 => => exporting layers                                                                                                                 0.9s
 => => writing image sha256:e159b85f65ab74a077a5d1e56dcb6333c7daa7faea12e7599a98540a425d09a3                                            0.0s
 => => naming to docker.io/library/mock                                                                                                 0.0s
```